### PR TITLE
refactor: refactor arm movement with non-blocking state machine

### DIFF
--- a/include/app/arm/ArmController.hpp
+++ b/include/app/arm/ArmController.hpp
@@ -38,6 +38,7 @@ public:
         GripStartBase,
         GripMoveShoulder,
         GripMoveElbow,
+        GripReady,
         // Reset (reversed order)
         ResetStartElbow,
         ResetMoveShoulder,
@@ -55,7 +56,7 @@ public:
     Stage getStage() const { return currentStage; }
 
     /**
-     * @brief Initialize the servos to their starting positions (center).
+     * @brief Initialize the servos to their starting positions.
      */
     void initializeServos();
 
@@ -66,15 +67,13 @@ public:
 
     /**
      * @brief Interpolates servo angles based on row/col position using bilinear interpolation.
-     * Calculate the 3 servo angles via bilinear interpolation to manually cordinated grid.
+     * Calculate the 3 servo angles via bilinear interpolation to manually coordinated grid.
      *
      * @param row Row index on the board (0–8). 0 is the top row, 8 is the bottom.
      * @param col Col index on the board (0–8). 0 is the leftmost column, 8 is the rightmost.
      * @return std::tuple<float, float, float> { baseAngle, shoulderAngle, elbowAngle }
      */
     std::tuple<float, float, float> interpolateAngles(int row, int col);
-
-    void placePieceAt(int row, int col);
 
     /**
      * @brief Turn on the pump and activate electromagnet to grip an object.

--- a/include/app/arm/ArmController.hpp
+++ b/include/app/arm/ArmController.hpp
@@ -33,30 +33,6 @@ public:
     void initializeServos();
 
     /**
-     * @brief Set the angle of the base servo (rotation around vertical axis).
-     *
-     * @param angle Desired angle in degrees. Positive: arm moves clockwise; negative: arm moves counter-clockwise.
-     * (The angle will be clamped within the servo's physical limits. See Servo.hpp for details)
-     */
-    void setBaseAngle(float angle);
-
-    /**
-     * @brief Set the angle of the shoulder servo (rotation around shoulder joint).
-     *
-     * @param angle Desired angle in degrees. Positive: arm moves forward; negative: arm moves backward.
-     * (The angle will be clamped within the servo's physical limits. See Servo.hpp for details)
-     */
-    void setShoulderAngle(float angle);
-
-    /**
-     * @brief Set the angle of the elbow servo (rotation around elbow joint).
-     *
-     * @param angle Desired angle in degrees. Positive: arm moves up; negative: arm moves down.
-     * (The angle will be clamped within the servo's physical limits. See Servo.hpp for details)
-     */
-    void setElbowAngle(float angle);
-
-    /**
      * @brief Reset all servos to their initial positions.
      */
     void resetServos();

--- a/include/app/arm/ArmController.hpp
+++ b/include/app/arm/ArmController.hpp
@@ -30,15 +30,17 @@ public:
     {
         // Idle
         Idle,
-        // Place
-        PlaceStartBase,
-        PlaceMoveShoulder,
-        PlaceMoveElbow,
         // Grip
         GripStartBase,
         GripMoveShoulder,
         GripMoveElbow,
+        GripDoGrip,
         GripReady,
+        // Place
+        PlaceStartBase,
+        PlaceMoveShoulder,
+        PlaceMoveElbow,
+        PlaceDoRelease,
         // Reset (reversed order)
         ResetStartElbow,
         ResetMoveShoulder,

--- a/include/driver/Servo.hpp
+++ b/include/driver/Servo.hpp
@@ -82,14 +82,6 @@ public:
     void setAngle(float angle);
 
     /**
-     * @brief Move servo smoothly to target angle using linear interpolation.
-     * @param targetAngle Target angle in degrees. (will be clamped to min/max).
-     * @param step Size of each angle increment in degrees (e.g., 10.0f means move in 10° steps).
-     * @param delayMs Delay in milliseconds between each step (e.g., 10ms per step).
-     */
-    void setAngleSmoothly(float targetAngle, float step = 10.0f, int delayMs = 50);
-
-    /**
      * @brief Get the current stored angle of the servo.
      */
     float getAngle() const { return currentAngle; }

--- a/src/app/arm/ArmController.cpp
+++ b/src/app/arm/ArmController.cpp
@@ -129,13 +129,21 @@ void ArmController::update()
         if (duration_cast<milliseconds>(now - stageStartTime).count() >= 500)
         {
             elbowServo.setAngle(60.0f);
-            // grip(); // Do grip()
             stageStartTime = now;
             currentStage = Stage::GripReady;
+    //         currentStage = Stage::GripDoGrip;
         }
         break;
+    // case Stage::GripDoGrip:
+    //     if (duration_cast<milliseconds>(now - stageStartTime).count() >= 500)
+    //     {
+    //         grip(); // Do grip()
+    //         stageStartTime = now;
+    //         currentStage = Stage::GripReady;
+    //     }
+    //     break;
     case Stage::GripReady:
-        if (duration_cast<milliseconds>(now - stageStartTime).count() >= 500)
+        if (duration_cast<milliseconds>(now - stageStartTime).count() >= 800)
         {
             elbowServo.setAngle(0.0f); // Draw back to avoid collision
             stageStartTime = now;
@@ -164,15 +172,23 @@ void ArmController::update()
         if (duration_cast<milliseconds>(now - stageStartTime).count() >= 500)
         {
             elbowServo.setAngle(targetElbow);
-            // release(); // Do release()
             stageStartTime = now;
             currentStage = Stage::ResetStartElbow;
+            // currentStage = Stage::PlaceDoRelease;
         }
         break;
+    // case Stage::PlaceDoRelease:
+    //     if (duration_cast<milliseconds>(now - stageStartTime).count() >= 500)
+    //     {
+    //         release(); // Do release()
+    //         stageStartTime = now;
+    //         currentStage = Stage::ResetStartElbow;
+    //     }
+    //     break;
 
     // Reset (reversed order)
     case Stage::ResetStartElbow:
-        if (duration_cast<milliseconds>(now - stageStartTime).count() >= 500)
+        if (duration_cast<milliseconds>(now - stageStartTime).count() >= 800)
         {
             elbowServo.setAngle(0.0f);
             stageStartTime = now;
@@ -180,7 +196,7 @@ void ArmController::update()
         }
         break;
     case Stage::ResetMoveShoulder:
-        if (duration_cast<milliseconds>(now - stageStartTime).count() >= 500)
+        if (duration_cast<milliseconds>(now - stageStartTime).count() >= 800)
         {
             shoulderServo.setAngle(0.0f);
             stageStartTime = now;

--- a/src/app/arm/ArmController.cpp
+++ b/src/app/arm/ArmController.cpp
@@ -1,8 +1,7 @@
 #include "ArmController.hpp"
-#include <thread>
 #include <chrono>
+#include <cmath>
 #include <iostream>
-#include <math.h>
 
 /**
  * @brief Construct a new ArmController object.
@@ -12,21 +11,16 @@
  * @param elbow Servo for the elbow joint
  */
 ArmController::ArmController(Servo &base, Servo &shoulder, Servo &elbow, Pump &pump, Electromagnet &magnet)
-    : baseServo(base), shoulderServo(shoulder), elbowServo(elbow), pump(pump), magnet(magnet) {}
+    : baseServo(base), shoulderServo(shoulder), elbowServo(elbow), pump(pump), magnet(magnet), currentStage(Stage::Idle) {}
 
 /**
  * @brief Initialize the servos to their starting positions (center).
  */
 void ArmController::initializeServos()
 {
-    elbowServo.setAngleSmoothly(0.0f);
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-
-    shoulderServo.setAngleSmoothly(0.0f);
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-
-    baseServo.setAngleSmoothly(0.0f);
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    stageStartTime = std::chrono::steady_clock::now();
+    currentStage = Stage::ResetStartElbow;
+    isInit = true;
 }
 
 /**
@@ -42,16 +36,16 @@ void ArmController::initializeServos()
  */
 const std::array<std::array<std::tuple<float, float, float>, 3>, 3> ArmController::cordinatedGrid =
     {{
-        {
-            {{-15.0f, 75.0f, 20.0f}, {0.0f, 70.0f, 25.0f}, {15.0f, 75.0f, 20.0f}}, // Top
-        },
-        {
-            {{-22.5f, 45.0f, 55.0f}, {0.0f, 45.0f, 55.0f}, {20.0f, 45.0f, 55.0f}}, // Middle
-        },
-        {
-            {{-25.0f, 30.0f, 65.0f}, {0.0f, 25.0f, 70.0f}, {30.0f, 30.0f, 65.0f}}, // Bottom
-        },
-    }};
+    {
+        {{-15.0f, 75.0f, 20.0f}, {0.0f, 70.0f, 25.0f}, {15.0f, 75.0f, 20.0f}}, // Top
+    },
+    {
+        {{-22.5f, 45.0f, 55.0f}, {0.0f, 45.0f, 55.0f}, {20.0f, 45.0f, 55.0f}}, // Middle
+    },
+    {
+        {{-25.0f, 30.0f, 65.0f}, {0.0f, 25.0f, 70.0f}, {30.0f, 30.0f, 65.0f}}, // Bottom
+    },
+}};
 
 /**
  * @brief Interpolates servo angles based on row/col position using bilinear interpolation.
@@ -93,18 +87,24 @@ std::tuple<float, float, float> ArmController::interpolateAngles(int row, int co
             a3 + (b3 - a3) * t};
     };
 
-    auto q11 = cordinatedGrid[r0][c0];
-    auto q21 = cordinatedGrid[r0][c1];
-    auto q12 = cordinatedGrid[r1][c0];
-    auto q22 = cordinatedGrid[r1][c1];
+    auto q11 = coordinatedGrid[r0][c0];
+    auto q21 = coordinatedGrid[r0][c1];
+    auto q12 = coordinatedGrid[r1][c0];
+    auto q22 = coordinatedGrid[r1][c1];
 
-    auto top = interpolate(q11, q21, fc);      // left to right on top
-    auto bottom = interpolate(q12, q22, fc);   // left to right on bottom
-    auto final = interpolate(top, bottom, fr); // top to bottom
+    auto top = interpolate(q11, q21, fc);      // Left to right on top
+    auto bottom = interpolate(q12, q22, fc);   // Left to right on bottom
+    auto final = interpolate(top, bottom, fr); // Top to bottom
 
     return final;
 }
 
+/**
+ * @brief Place piece at targetting location.
+ *
+ * @param row Board row (arm coordinate system)
+ * @param col Board col (arm coordinate system)
+ */
 void ArmController::placePieceAt(int row, int col)
 {
     if (row < 0 || row > 8 || col < 0 || col > 8)
@@ -113,20 +113,124 @@ void ArmController::placePieceAt(int row, int col)
         return;
     }
 
-    auto [base, shoulder, elbow] = interpolateAngles(row, col);
+    std::tie(targetBase, targetShoulder, targetElbow) = interpolateAngles(row, col);
+    stageStartTime = std::chrono::steady_clock::now();
+    currentStage = Stage::PlaceStartBase;
+}
 
-    // Test code
-    // std::cout << "[TEST] Placing at board coordinate: (" << row << ", " << col << ")\n";
-    // std::cout << "[TEST] Interpolated angles: base=" << base
-    //           << ", shoulder=" << shoulder
-    //           << ", elbow=" << elbow << "\n";
+/**
+ * @brief Periodically update the arm placement sequence in a non-blocking way.
+ *
+ */
+void ArmController::update()
+{
+    using namespace std::chrono;
+    auto now = steady_clock::now();
 
-    setBaseAngle(base);
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    setShoulderAngle(shoulder);
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-    setElbowAngle(elbow);
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    switch (currentStage)
+    {
+    // Idle
+    case Stage::Idle:
+        break;
+    // Grip
+    case Stage::GripStartBase:
+        if (duration_cast<milliseconds>(now - stageStartTime).count() >= 500)
+        {
+            baseServo.setAngleSmoothly(-90.0f);
+            stageStartTime = now;
+            currentStage = Stage::GripMoveShoulder;
+        }
+        break;
+    case Stage::GripMoveShoulder:
+        if (duration_cast<milliseconds>(now - stageStartTime).count() >= 500)
+        {
+            shoulderServo.setAngleSmoothly(30.0f);
+            stageStartTime = now;
+            currentStage = Stage::GripMoveElbow;
+        }
+        break;
+    case Stage::GripMoveElbow:
+        if (duration_cast<milliseconds>(now - stageStartTime).count() >= 500)
+        {
+            elbowServo.setAngleSmoothly(60.0f);
+            grip(); // Do grip()
+            stageStartTime = now;
+            currentStage = Stage::ResetStartElbow;
+        }
+        break;
+
+    // Place
+    case Stage::PlaceStartBase:
+        if (duration_cast<milliseconds>(now - stageStartTime).count() >= 500)
+        {
+            baseServo.setAngleSmoothly(targetBase);
+            stageStartTime = now;
+            currentStage = Stage::PlaceMoveShoulder;
+        }
+        break;
+    case Stage::PlaceMoveShoulder:
+        if (duration_cast<milliseconds>(now - stageStartTime).count() >= 500)
+        {
+            shoulderServo.setAngleSmoothly(targetShoulder);
+            stageStartTime = now;
+            currentStage = Stage::PlaceMoveElbow;
+        }
+        break;
+    case Stage::PlaceMoveElbow:
+        if (duration_cast<milliseconds>(now - stageStartTime).count() >= 500)
+        {
+            elbowServo.setAngleSmoothly(targetElbow);
+            release(); // Do release()
+            stageStartTime = now;
+            currentStage = Stage::ResetStartElbow;
+        }
+        break;
+
+    // Reset (reversed order)
+    case Stage::ResetStartElbow:
+        if (duration_cast<milliseconds>(now - stageStartTime).count() >= 500)
+        {
+            elbowServo.setAngleSmoothly(0.0f);
+            stageStartTime = now;
+            currentStage = Stage::ResetMoveShoulder;
+        }
+        break;
+    case Stage::ResetMoveShoulder:
+        if (duration_cast<milliseconds>(now - stageStartTime).count() >= 500)
+        {
+            shoulderServo.setAngleSmoothly(0.0f);
+            stageStartTime = now;
+            currentStage = Stage::ResetMoveBase;
+        }
+        break;
+    case Stage::ResetMoveBase:
+        if (duration_cast<milliseconds>(now - stageStartTime).count() >= 500)
+        {
+            baseServo.setAngleSmoothly(0.0f);
+            stageStartTime = now;
+            currentStage = Stage::CompleteWait;
+        }
+        break;
+
+    // Complete
+    case Stage::CompleteWait:
+        if (duration_cast<milliseconds>(now - stageStartTime).count() >= 100)
+        {
+            if (isInit)
+            {
+                std::cout << "[ARM] Initialization complete.\n";
+                currentStage = Stage::Idle;
+                isInit = false;
+            }
+            else
+            {
+                currentStage = Stage::Completed;
+            }
+        }
+        break;
+    case Stage::Completed:
+        break;
+    }
 }
 
 /**
@@ -134,14 +238,8 @@ void ArmController::placePieceAt(int row, int col)
  */
 void ArmController::resetServos()
 {
-    elbowServo.setAngleSmoothly(0.0f);
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-
-    shoulderServo.setAngleSmoothly(0.0f);
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-
-    baseServo.setAngleSmoothly(0.0f);
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    stageStartTime = std::chrono::steady_clock::now();
+    currentStage = Stage::ResetStartElbow;
 }
 
 /**
@@ -150,17 +248,16 @@ void ArmController::resetServos()
 void ArmController::grip()
 {
     pump.turnOn();
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
     magnet.activate();
 }
 
 /**
- * @brief Deactivate the electromagnet and turn off the pump to release an object.
+ * @brief Deactivate the electromagnet and turn off the pump to release an
+ * object.
  */
 void ArmController::release()
 {
     magnet.deactivate();
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
     pump.turnOff();
 }
 
@@ -169,23 +266,24 @@ void ArmController::release()
  */
 void ArmController::gripNewPiece()
 {
-    baseServo.setAngleSmoothly(-90.0f);
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-
-    shoulderServo.setAngleSmoothly(30.0f);
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-
-    elbowServo.setAngleSmoothly(60.0f);
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-
-    grip();
+    stageStartTime = std::chrono::steady_clock::now();
+    currentStage = Stage::GripStartBase;
 }
 
+/**
+ * @brief Starts the background thread for executing arm tasks.
+ */
 void ArmController::startWorker()
 {
     workerThread = std::thread(&ArmController::workerLoop, this);
 }
 
+/**
+ * @brief Adds a move task to the execution queue.
+ *
+ * @param row Board row (arm coordinate system)
+ * @param col Board col (arm coordinate system)
+ */
 void ArmController::enqueueMove(int row, int col)
 {
     std::lock_guard<std::mutex> lock(queueMutex);
@@ -193,22 +291,36 @@ void ArmController::enqueueMove(int row, int col)
     cv.notify_one();
 }
 
+/**
+ * @brief Background thread loop for handling queued arm tasks.
+ */
 void ArmController::workerLoop()
 {
     while (running)
     {
         std::unique_lock<std::mutex> lock(queueMutex);
-        cv.wait(lock, [&]
-                { return !taskQueue.empty(); });
+        cv.wait(lock, [&] { return !taskQueue.empty(); });
+        if (!running)
+            return;
 
         auto [row, col] = taskQueue.front();
         taskQueue.pop();
         lock.unlock();
 
-        // armController->gripNewPiece();
+        // gripNewPiece();
+        // while (running && currentStage != Stage::Completed)
+        // {
+        //     std::this_thread::sleep_for(std::chrono::milliseconds(10)); // Minimal delay for polling
+        //     update();                                                   // Polling
+        // }
+
         placePieceAt(row, col);
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-        // armController->release();
+        while (running && currentStage != Stage::Completed)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10)); // Minimal delay for polling
+            update();                                                   // Polling
+        }
+
         resetServos();
     }
 }

--- a/src/app/arm/ArmController.cpp
+++ b/src/app/arm/ArmController.cpp
@@ -24,7 +24,7 @@ void ArmController::initializeServos()
 }
 
 /**
- * @brief Manually cordinated grid for 9 points
+ * @brief Manually coordinated grid for 9 points
  * Each tuple records a set of servo angles:
  * std::tuple<float, float, float> { baseAngle, shoulderAngle, elbowAngle }
  * The grid is as follows:
@@ -34,7 +34,7 @@ void ArmController::initializeServos()
  *  ...
  * (8, 0) ... (8, 4) ... (8, 8)
  */
-const std::array<std::array<std::tuple<float, float, float>, 3>, 3> ArmController::cordinatedGrid =
+const std::array<std::array<std::tuple<float, float, float>, 3>, 3> ArmController::coordinatedGrid =
     {{
     {
         {{-15.0f, 75.0f, 20.0f}, {0.0f, 70.0f, 25.0f}, {15.0f, 75.0f, 20.0f}}, // Top
@@ -49,7 +49,7 @@ const std::array<std::array<std::tuple<float, float, float>, 3>, 3> ArmControlle
 
 /**
  * @brief Interpolates servo angles based on row/col position using bilinear interpolation.
- * Calculate the 3 servo angles via bilinear interpolation to manually cordinated grid.
+ * Calculate the 3 servo angles via bilinear interpolation to manually coordinated grid.
  *
  * @param row Row index [0, 8]
  * @param col Column index [0, 8]

--- a/src/app/arm/ArmController.cpp
+++ b/src/app/arm/ArmController.cpp
@@ -136,7 +136,7 @@ void ArmController::update()
     case Stage::GripStartBase:
         if (duration_cast<milliseconds>(now - stageStartTime).count() >= 500)
         {
-            baseServo.setAngleSmoothly(-90.0f);
+            baseServo.setAngle(-90.0f);
             stageStartTime = now;
             currentStage = Stage::GripMoveShoulder;
         }
@@ -144,7 +144,7 @@ void ArmController::update()
     case Stage::GripMoveShoulder:
         if (duration_cast<milliseconds>(now - stageStartTime).count() >= 500)
         {
-            shoulderServo.setAngleSmoothly(30.0f);
+            shoulderServo.setAngle(30.0f);
             stageStartTime = now;
             currentStage = Stage::GripMoveElbow;
         }
@@ -152,7 +152,7 @@ void ArmController::update()
     case Stage::GripMoveElbow:
         if (duration_cast<milliseconds>(now - stageStartTime).count() >= 500)
         {
-            elbowServo.setAngleSmoothly(60.0f);
+            elbowServo.setAngle(60.0f);
             grip(); // Do grip()
             stageStartTime = now;
             currentStage = Stage::ResetStartElbow;
@@ -163,7 +163,7 @@ void ArmController::update()
     case Stage::PlaceStartBase:
         if (duration_cast<milliseconds>(now - stageStartTime).count() >= 500)
         {
-            baseServo.setAngleSmoothly(targetBase);
+            baseServo.setAngle(targetBase);
             stageStartTime = now;
             currentStage = Stage::PlaceMoveShoulder;
         }
@@ -171,7 +171,7 @@ void ArmController::update()
     case Stage::PlaceMoveShoulder:
         if (duration_cast<milliseconds>(now - stageStartTime).count() >= 500)
         {
-            shoulderServo.setAngleSmoothly(targetShoulder);
+            shoulderServo.setAngle(targetShoulder);
             stageStartTime = now;
             currentStage = Stage::PlaceMoveElbow;
         }
@@ -179,7 +179,7 @@ void ArmController::update()
     case Stage::PlaceMoveElbow:
         if (duration_cast<milliseconds>(now - stageStartTime).count() >= 500)
         {
-            elbowServo.setAngleSmoothly(targetElbow);
+            elbowServo.setAngle(targetElbow);
             release(); // Do release()
             stageStartTime = now;
             currentStage = Stage::ResetStartElbow;
@@ -190,7 +190,7 @@ void ArmController::update()
     case Stage::ResetStartElbow:
         if (duration_cast<milliseconds>(now - stageStartTime).count() >= 800)
         {
-            elbowServo.setAngleSmoothly(0.0f);
+            elbowServo.setAngle(0.0f);
             stageStartTime = now;
             currentStage = Stage::ResetMoveShoulder;
         }
@@ -198,7 +198,7 @@ void ArmController::update()
     case Stage::ResetMoveShoulder:
         if (duration_cast<milliseconds>(now - stageStartTime).count() >= 500)
         {
-            shoulderServo.setAngleSmoothly(0.0f);
+            shoulderServo.setAngle(0.0f);
             stageStartTime = now;
             currentStage = Stage::ResetMoveBase;
         }
@@ -206,7 +206,7 @@ void ArmController::update()
     case Stage::ResetMoveBase:
         if (duration_cast<milliseconds>(now - stageStartTime).count() >= 500)
         {
-            baseServo.setAngleSmoothly(0.0f);
+            baseServo.setAngle(0.0f);
             stageStartTime = now;
             currentStage = Stage::CompleteWait;
         }

--- a/src/app/arm/ArmController.cpp
+++ b/src/app/arm/ArmController.cpp
@@ -30,39 +30,6 @@ void ArmController::initializeServos()
 }
 
 /**
- * @brief Set the angle of the base servo.
- *
- * @param angle Desired angle in degrees.
- * (The angle will be clamped within the servo's physical limits. See Servo.hpp for details)
- */
-void ArmController::setBaseAngle(float angle)
-{
-    baseServo.setAngleSmoothly(angle);
-}
-
-/**
- * @brief Set the angle of the shoulder servo.
- *
- * @param angle Desired angle in degrees.
- * (The angle will be clamped within the servo's physical limits. See Servo.hpp for details)
- */
-void ArmController::setShoulderAngle(float angle)
-{
-    shoulderServo.setAngleSmoothly(angle);
-}
-
-/**
- * @brief Set the angle of the elbow servo.
- *
- * @param angle Desired angle in degrees.
- * (The angle will be clamped within the servo's physical limits. See Servo.hpp for details)
- */
-void ArmController::setElbowAngle(float angle)
-{
-    elbowServo.setAngleSmoothly(angle);
-}
-
-/**
  * @brief Manually cordinated grid for 9 points
  * Each tuple records a set of servo angles:
  * std::tuple<float, float, float> { baseAngle, shoulderAngle, elbowAngle }

--- a/src/app/arm/ArmController.cpp
+++ b/src/app/arm/ArmController.cpp
@@ -188,7 +188,7 @@ void ArmController::update()
 
     // Reset (reversed order)
     case Stage::ResetStartElbow:
-        if (duration_cast<milliseconds>(now - stageStartTime).count() >= 500)
+        if (duration_cast<milliseconds>(now - stageStartTime).count() >= 800)
         {
             elbowServo.setAngleSmoothly(0.0f);
             stageStartTime = now;

--- a/src/driver/Servo.cpp
+++ b/src/driver/Servo.cpp
@@ -16,34 +16,3 @@ void Servo::setAngle(float angle)
 
     pca->setPulseWidth(config.channel, pulseUs);
 }
-
-void Servo::setAngleSmoothly(float targetAngle, float step, int delayMs)
-{
-    // Ignore small angle changes below resolution threshold, as servos can't respond to tiny pulse width variations
-    const float resolution = 10.0f;
-    float current = this->currentAngle;
-
-    // If the angle difference is smaller than resolution, move directly to target
-    if (std::abs(targetAngle - current) < resolution)
-    {
-        setAngle(targetAngle);
-        this->currentAngle = targetAngle;
-        return;
-    }
-
-    step = std::max(step, resolution);
-
-    float direction = (targetAngle > current) ? 1.0f : -1.0f;
-    float a = current;
-
-    while (std::abs(a - targetAngle) >= resolution)
-    {
-        a += step * direction;
-        setAngle(a);
-        std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
-    }
-
-    // Final adjustment to reach the exact target angle
-    setAngle(targetAngle);
-    this->currentAngle = targetAngle;
-}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,7 +53,7 @@ int main()
         while (arm.getStage() != ArmController::Stage::Idle)
         {
             arm.update();
-            std::this_thread::sleep_for(std::chrono::milliseconds(10)); // Minimal delay for pulling
+            std::this_thread::sleep_for(std::chrono::milliseconds(10)); // Minimal delay for polling
         }
         std::cout << "[MAIN] Arm initialization complete. Starting worker thread...\n";
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,8 @@
 #include "Pump.hpp"
 #include "Electromagnet.hpp"
 #include <iostream>
+#include <chrono>
+#include <thread>
 
 // Config
 #define LINE_NUM 9
@@ -14,7 +16,8 @@
 #define BLACK_PIECE 1
 #define WHITE_PIECE 2
 
-ArmController& createArmController()
+// Create and initialize hardware interfaces
+ArmController &createArmController()
 {
     static PCA9685Driver pca;
 
@@ -25,7 +28,8 @@ ArmController& createArmController()
     static Electromagnet magnet(&pca, MAGNET_CHANNEL);
 
     static bool initialized = false;
-    if (!initialized) {
+    if (!initialized)
+    {
         pca.begin();
         pca.setPWMFreq(50);
         initialized = true;
@@ -45,6 +49,15 @@ int main()
         // Initialize arm module
         ArmController& arm = createArmController();
         arm.initializeServos();
+
+        while (arm.getStage() != ArmController::Stage::Idle)
+        {
+            arm.update();
+            std::this_thread::sleep_for(std::chrono::milliseconds(10)); // Minimal delay for pulling
+        }
+        std::cout << "[MAIN] Arm initialization complete. Starting worker thread...\n";
+
+        // Start arm module thread
         arm.startWorker();
 
         // Initialize coordinator module
@@ -54,7 +67,22 @@ int main()
         GomokuVision vision(CAMERA_NUM, BOARD_SIZE, LINE_NUM);
         vision.registerCallback(&coordinator);
 
-        vision.run();
+        // Start vision module in a separate thread
+        std::thread visionThread(
+            [&]()
+            {
+                try
+                {
+                    vision.run();
+                }
+                catch (const std::exception &e)
+                {
+                    std::cerr << "[Vision Thread Exception] " << e.what() << std::endl;
+                    std::abort();
+                }
+            });
+
+        visionThread.join();
     }
     catch (const std::exception &e)
     {


### PR DESCRIPTION
Use a time-driven state machine combined with non-blocking polling to control the robotic arm instead of sleep_for().

Since standard PWM servos provide no motion feedback, event-driven callbacks are not feasible. Instead, I split each action into timed stages and periodically check for completion using `std::chrono`.

The arm controller state machine runs in its own thread, so it doesn't block the main control or vision logic.